### PR TITLE
Corrige configuração SecurityConfig para Spring Security 6

### DIFF
--- a/src/main/java/com/laispsicologia/PsychologySchedule/config/SecurityConfig.java
+++ b/src/main/java/com/laispsicologia/PsychologySchedule/config/SecurityConfig.java
@@ -1,20 +1,27 @@
 package com.laispsicologia.PsychologySchedule.config;
 
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
+@EnableWebSecurity
 public class SecurityConfig {
-    @Bean
-    SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
-        httpSecurity.csrf(csrf -> csrf.disable()).authorizeHttpRequests(auth ->{
-            auth.requestMatchers("/appointments").permitAll()
-                    .requestMatchers("/clients").permitAll();
-        });
-        return httpSecurity.build();
-    }
 
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/appointments/**").permitAll()
+                        .requestMatchers("/clients/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .httpBasic(Customizer.withDefaults()); // Se desejar autenticação básica
+
+        return http.build();
+    }
 }

--- a/src/main/java/com/laispsicologia/PsychologySchedule/config/WebConfig.java
+++ b/src/main/java/com/laispsicologia/PsychologySchedule/config/WebConfig.java
@@ -1,4 +1,5 @@
 package com.laispsicologia.PsychologySchedule.config;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -10,13 +11,14 @@ public class WebConfig {
     @Bean
     public WebMvcConfigurer corsConfigurer() {
         return new WebMvcConfigurer() {
+
             @Override
             public void addCorsMappings(CorsRegistry registry) {
-                registry.addMapping("/**") // permite em todos os endpoints
-                        .allowedOrigins("http://localhost:4200") // URL do seu Angular
+                registry.addMapping("/**")                            // aplica a todos os endpoints
+                        .allowedOrigins("http://localhost:4200")     // URL do Angular frontend
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                         .allowedHeaders("*")
-                        .allowCredentials(true); // se estiver usando cookies/autenticação
+                        .allowCredentials(true);                      // importante para autenticação com cookies
             }
         };
     }


### PR DESCRIPTION
Fiz, um ajuste na configuração dos arquivos SecurityConfig e WebConfig para liberar os endpoints e corrigir problema de CORS, que estava dando no angular, quando estava tentando acessar outras rotas fora a de appointment. pois estava dando erro de bloqueio 403 (Forbidden). fiz um teste no Postman primeiro pra se certificar que era esse o erro. 
Principais alterações:

No SecurityConfig, atualizei as regras para permitir acesso livre (permitAll) a todos os endpoints que começam com /appointments/** e /clients/**, garantindo que todos os métodos GET, POST, PUT, DELETE sejam liberados sem exigir autenticação. Por enquanto, ja que não estamos utilizando autenticação.

No WebConfig, ajustei a configuração de CORS para permitir requisições vindas de http://localhost:4200 (URL do frontend no Angular), com todos os métodos HTTP necessários.

Atualizei a configuração para ser compatível com a versão atual do Spring Security (versão 6), evitando warnings e erros.

Com isso, o frontend consegue consumir os serviços sem erros de autorização ou CORS, garantindo o funcionamento correto do sistema.